### PR TITLE
#17 のワークアラウンドを実装

### DIFF
--- a/Osmy.Server/Data/SoftwareDbContext.cs
+++ b/Osmy.Server/Data/SoftwareDbContext.cs
@@ -15,6 +15,8 @@ namespace Osmy.Server.Data
 
         public DbSet<ChecksumVerificationResultCollection> ChecksumVerificationResults { get; set; }
 
+        public DbSet<SbomFile> Files { get; set; }
+
         public SoftwareDbContext()
         {
             var appDataDir = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
@@ -47,6 +49,8 @@ namespace Osmy.Server.Data
             modelBuilder.Entity<SbomExternalReference>()
                 .HasDiscriminator()
                 .HasValue<SpdxExternalReference>("external_ref_spdx");
+
+            modelBuilder.Entity<SbomFile>().ToTable("SbomFile");
         }
     }
 }


### PR DESCRIPTION
#17 のワークアラウンドとして，SBOMのファイル情報取得処理を変更しました．
Contentが大量に複製されてメモリ消費量が瞬間的に大きくなる問題は改善されています．